### PR TITLE
Fix path; image saves to the correct location because that routine us…

### DIFF
--- a/Model/Banner.php
+++ b/Model/Banner.php
@@ -31,7 +31,7 @@ namespace Magestore\Bannerslider\Model;
  */
 class Banner extends \Magento\Framework\Model\AbstractModel
 {
-    const BASE_MEDIA_PATH = 'magestore/bannerslider/images';
+    const BASE_MEDIA_PATH = 'magestore/bannerslider/images/';
 
     const BANNER_TARGET_SELF = 0;
     const BANNER_TARGET_PARENT = 1;


### PR DESCRIPTION
…es getAbsolutePath, but data[‘image’] value is saved without trailing slash, which results in path errors that aren’t resolved (404s)… issue found using NGINX in Magento default mode (theoretically, apache redirects fix the path? not sure why this is working correctly otherwise…)